### PR TITLE
fix: use request headers for controller throtlling

### DIFF
--- a/packages/backend/src/faucet/faucet.controller.ts
+++ b/packages/backend/src/faucet/faucet.controller.ts
@@ -1,13 +1,15 @@
-import { Body, Controller, Headers, Post } from '@nestjs/common'
+import { Body, Controller, Headers, Post, UseGuards } from '@nestjs/common'
 
 import { GetSubnetAssetsDto } from './faucet.dto'
 import { FaucetService } from './faucet.service'
+import { ThrottlerBehindProxyGuard } from './throttler.guard'
 
 @Controller('faucet')
 export class FaucetController {
   constructor(private faucetService: FaucetService) {}
 
   @Post('getSubnetAssets')
+  @UseGuards(ThrottlerBehindProxyGuard)
   async getSubnetAssets(
     @Body() getSubnetAssetsDto: GetSubnetAssetsDto,
     @Headers('traceparent') traceparent: string

--- a/packages/backend/src/faucet/throttler.guard.ts
+++ b/packages/backend/src/faucet/throttler.guard.ts
@@ -1,0 +1,11 @@
+import { ThrottlerGuard } from '@nestjs/throttler'
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class ThrottlerBehindProxyGuard extends ThrottlerGuard {
+  protected getTracker(req: Record<string, any>) {
+    console.log('IPs from request headers', req.ips)
+    console.log('IP from request', req.ip)
+    return req.ips.length ? req.ips[0] : req.ip
+  }
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -12,8 +12,6 @@ import 'antd/dist/reset.css'
 import useTheme from './hooks/useTheme'
 import FaucetForm from './components/FaucetForm'
 import Content from './components/Content'
-// import { SERVICE_NAME } from './tracing'
-// import { trace } from '@opentelemetry/api'
 import { TracingContext } from './contexts/tracing'
 import { SubnetWithId } from './types'
 import useRegisteredSubnets from './hooks/useRegisteredSubnets'
@@ -79,22 +77,14 @@ const App = () => {
     [registeredSubnets]
   )
 
-  const transaction = useMemo(() => {
-    return apm.startTransaction('root', 'app', { managed: true })
-    // const tracer = trace.getTracer(SERVICE_NAME)
-    // return tracer.startSpan('root')
-  }, [])
-
-  // useEffect(function init() {
-  //   return function onPageClosed() {
-  //     console.log('end root')
-  //     transaction?.end()
-  //   }
-  // }, [])
+  const apmTransaction = useMemo(
+    () => apm.startTransaction('root', 'app', { managed: true }),
+    []
+  )
 
   return (
     <ThemeProvider theme={theme}>
-      <TracingContext.Provider value={{ transaction }}>
+      <TracingContext.Provider value={{ transaction: apmTransaction }}>
         <ErrorsContext.Provider value={{ setErrors }}>
           <SubnetsContext.Provider
             value={{


### PR DESCRIPTION
# Description

This PR adds a throttler guard to get the client IP address from request headers if any, so that throttling works with proxying the faucet with a load balancer.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
