### PR TITLE
fix: deactivate rate limiting

### DIFF
--- a/packages/backend/src/app/app.module.ts
+++ b/packages/backend/src/app/app.module.ts
@@ -17,10 +17,10 @@ const THROTTLER_TTL_SECONDS = process.env.THROTTLER_TTL_SECONDS
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', '..', '..', 'frontend', 'dist'),
     }),
-    ThrottlerModule.forRoot({
-      ttl: THROTTLER_TTL_SECONDS,
-      limit: 1,
-    }),
+    // ThrottlerModule.forRoot({
+    //   ttl: THROTTLER_TTL_SECONDS,
+    //   limit: 1,
+    // }),
     FaucetModule,
   ],
   providers: [


### PR DESCRIPTION
# Description

This PR deactivates rate limiting to not prevent users from testing Topos while we investigate why rate limiting is flaky.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
