### PR TITLE
feat: update APM instrumentation

### DIFF
--- a/packages/backend/src/apm/apm.module.ts
+++ b/packages/backend/src/apm/apm.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+
+import { ApmService } from './apm.service'
+
+@Module({
+  imports: [ConfigModule],
+  exports: [ApmService],
+  providers: [ApmService],
+})
+export class ApmModule {}

--- a/packages/backend/src/apm/apm.service.ts
+++ b/packages/backend/src/apm/apm.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import apm, * as ElasticAPM from 'elastic-apm-node'
+
+@Injectable()
+export class ApmService {
+  private _apm: ElasticAPM.Agent
+
+  constructor(private configService: ConfigService) {
+    this._apm = ElasticAPM.start({
+      serviceName:
+        this.configService.get('TRACING_SERVICE_NAME') || 'faucet-server',
+      secretToken: this.configService.get('ELASTIC_APM_TOKEN') || '',
+      serverUrl: this.configService.get('ELASTIC_APM_ENDPOINT') || '',
+      environment:
+        this.configService.get('TRACING_SERVICE_VERSION') || 'unknown',
+      captureBody: 'all',
+    })
+  }
+
+  startTransaction(name: string, traceparent?: string) {
+    return this._apm.startTransaction(
+      name,
+      traceparent
+        ? {
+            childOf: traceparent,
+          }
+        : undefined
+    )
+  }
+
+  startChildSpan(name: string) {
+    return this._apm.startSpan(name)
+  }
+
+  captureError(error: string) {
+    this._apm.captureError(error)
+  }
+}

--- a/packages/backend/src/faucet/faucet.module.ts
+++ b/packages/backend/src/faucet/faucet.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common'
 
+import { ApmModule } from '../apm/apm.module'
 import { FaucetController } from './faucet.controller'
 import { FaucetService } from './faucet.service'
 
 @Module({
   controllers: [FaucetController],
+  imports: [ApmModule],
   providers: [FaucetService],
 })
 export class FaucetModule {}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -1,24 +1,9 @@
 import { ValidationPipe } from '@nestjs/common'
 import { Logger } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
-import * as ElasticAPM from 'elastic-apm-node'
 
 import { AppModule } from './app/app.module'
 import { NestExpressApplication } from '@nestjs/platform-express'
-
-export const SERVICE_NAME = process.env.TRACING_SERVICE_NAME || 'faucet-server'
-export const SERVICE_VERSION = process.env.TRACING_SERVICE_VERSION || 'unknown'
-export const ELASTIC_APM_ENDPOINT = process.env.ELASTIC_APM_ENDPOINT || ''
-export const ELASTIC_APM_TOKEN = process.env.ELASTIC_APM_TOKEN || ''
-
-export const apm = ElasticAPM.start({
-  serviceName: SERVICE_NAME,
-  secretToken: ELASTIC_APM_TOKEN,
-  serverUrl: ELASTIC_APM_ENDPOINT,
-  environment: 'local',
-  opentelemetryBridgeEnabled: true,
-  captureBody: 'all',
-})
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule)

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,8 +1,7 @@
-import { apm } from '@elastic/apm-rum'
 import { ThemeProvider } from '@emotion/react'
 import styled from '@emotion/styled'
 import { Alert, Layout as AntdLayout } from 'antd'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { ErrorsContext } from './contexts/errors'
 import Footer from './components/Footer'
@@ -12,7 +11,6 @@ import 'antd/dist/reset.css'
 import useTheme from './hooks/useTheme'
 import FaucetForm from './components/FaucetForm'
 import Content from './components/Content'
-import { TracingContext } from './contexts/tracing'
 import { SubnetWithId } from './types'
 import useRegisteredSubnets from './hooks/useRegisteredSubnets'
 import { BigNumber, ethers } from 'ethers'
@@ -86,59 +84,46 @@ const App = () => {
     [registeredSubnets]
   )
 
-  const apmTransaction = useMemo(
-    () => apm.startTransaction('root', 'app', { managed: true }),
-    []
-  )
-
   return (
     <ThemeProvider theme={theme}>
-      <TracingContext.Provider value={{ transaction: apmTransaction }}>
-        <ErrorsContext.Provider value={{ setErrors }}>
-          <SuccessesContext.Provider value={{ setSuccesses }}>
-            <SubnetsContext.Provider
-              value={{
-                loading: !Boolean(subnets),
-                data: subnets,
-              }}
-            >
-              <Layout>
-                <Header />
-                {Boolean(errors.length) && (
-                  <Errors>
-                    {errors.map((e) => (
-                      <Alert
-                        type="error"
-                        showIcon
-                        closable
-                        message={e}
-                        key={e}
-                      />
-                    ))}
-                  </Errors>
-                )}
-                {Boolean(successes.length) && (
-                  <Successes>
-                    {successes.map((e) => (
-                      <Alert
-                        type="success"
-                        showIcon
-                        closable
-                        message={e}
-                        key={e}
-                      />
-                    ))}
-                  </Successes>
-                )}
-                <Content>
-                  <FaucetForm />
-                </Content>
-                <Footer />
-              </Layout>
-            </SubnetsContext.Provider>
-          </SuccessesContext.Provider>
-        </ErrorsContext.Provider>
-      </TracingContext.Provider>
+      <ErrorsContext.Provider value={{ setErrors }}>
+        <SuccessesContext.Provider value={{ setSuccesses }}>
+          <SubnetsContext.Provider
+            value={{
+              loading: !Boolean(subnets),
+              data: subnets,
+            }}
+          >
+            <Layout>
+              <Header />
+              {Boolean(errors.length) && (
+                <Errors>
+                  {errors.map((e) => (
+                    <Alert type="error" showIcon closable message={e} key={e} />
+                  ))}
+                </Errors>
+              )}
+              {Boolean(successes.length) && (
+                <Successes>
+                  {successes.map((e) => (
+                    <Alert
+                      type="success"
+                      showIcon
+                      closable
+                      message={e}
+                      key={e}
+                    />
+                  ))}
+                </Successes>
+              )}
+              <Content>
+                <FaucetForm />
+              </Content>
+              <Footer />
+            </Layout>
+          </SubnetsContext.Provider>
+        </SuccessesContext.Provider>
+      </ErrorsContext.Provider>
     </ThemeProvider>
   )
 }

--- a/packages/frontend/src/contexts/tracing.ts
+++ b/packages/frontend/src/contexts/tracing.ts
@@ -1,8 +1,0 @@
-import { Transaction } from '@elastic/apm-rum'
-import React from 'react'
-
-interface TracingContext {
-  transaction?: Transaction
-}
-
-export const TracingContext = React.createContext<TracingContext>({})

--- a/packages/frontend/src/hooks/useGetSubnetAsset.ts
+++ b/packages/frontend/src/hooks/useGetSubnetAsset.ts
@@ -1,4 +1,3 @@
-import { apm } from '@elastic/apm-rum'
 import axios from 'axios'
 import { useCallback, useContext, useState } from 'react'
 
@@ -37,8 +36,6 @@ export default function useGetSubnetAsset() {
             resolve()
           })
           .catch((error) => {
-            apm.captureError(error)
-
             let _error: string
             switch (error?.response?.status) {
               case 429: // Too many requests


### PR DESCRIPTION
# Description

This PR updates the APM instrumentation to focus on frontend->backend requests and get a different APM Transaction per request. New labels are also added to make sure we know everything about users' requests.

Fixes TOO-341

## Additions and Changes

- NodeJS APM agent bootstrapped changes from local in `main.ts` to an actual NestJS service (similarly to what was recently done on the Executor Service)
- Elastic RUM (browser) instrumentation now creates a different APM transaction per faucet backend request
- New labels show complete data about users' requests

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
