### PR TITLE
fix: filter out external subnets

### DIFF
--- a/packages/frontend/src/hooks/useRegisteredSubnets.ts
+++ b/packages/frontend/src/hooks/useRegisteredSubnets.ts
@@ -68,11 +68,12 @@ export default function useRegisteredSubnets() {
         i++
       }
 
-      const subnets = await Promise.allSettled(promises).then((values) =>
-        values
-          .filter((v) => v.status === 'fulfilled')
-          .map((v) => (v.status === 'fulfilled' ? v.value : undefined))
-          .filter((v) => v)
+      const subnets = await Promise.allSettled(promises).then(
+        (values) =>
+          values
+            .filter((v) => v.status === 'fulfilled')
+            .map((v) => (v.status === 'fulfilled' ? v.value : undefined))
+            .filter((v) => v && v.name === 'Incal') // TMP, to filter out external subnets
       )
       setRegisteredSubnets(subnets as SubnetWithId[])
     }


### PR DESCRIPTION
# Description

This PR filters out external subnets so that only Topos and Incal are usable with the faucet.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
